### PR TITLE
refactor: Doc comments from Parameter AstNode.

### DIFF
--- a/example/lib/runner.g.dart
+++ b/example/lib/runner.g.dart
@@ -37,10 +37,13 @@ class MergeCommand extends Command {
   ArgParser get argParser => ArgParser()
     ..addOption(
       'branch',
+      help: 'The name of the branch to be merged into the current branch.',
       mandatory: true,
     )
     ..addOption(
       'strategy',
+      help:
+          'Pass merge strategy specific option through to the merge strategy.',
       defaultsTo: 'ort',
       mandatory: false,
       allowed: [
@@ -52,7 +55,10 @@ class MergeCommand extends Command {
         'subtree',
       ],
     )
-    ..addFlag('commit');
+    ..addFlag(
+      'commit',
+      help: 'Perform the merge and commit the result.',
+    );
 
   @override
   Future<void> run() {

--- a/example/lib/stash.dart
+++ b/example/lib/stash.dart
@@ -11,28 +11,11 @@ part 'stash.g.dart';
 class StashSubcommand extends _$StashSubcommand {
   /// Save your local modifications to a new stash.
   @cliCommand
-  Future<void> myCustomCommand({
-    // Required parameters will be shown to the user as `mandatory`
-    required String name,
-
-    // Optional and/or nullable parameters are not `mandatory`
-    int? age,
-
-    // Default values are also shown in the help text
-    String defaultPath = '~/',
-
-    /// Use doc comments (i.e. 3 slashes) to display a description of the parameter
-    String? someDocumentedParameter,
-
-    // You can override any generated values using `@Option`
-    @Option(
-      help: 'A custom help message for the parameter',
-      defaultsTo: 42,
-    )
-    int? customParameter,
+  Future<void> push({
+    String message = 'WIP',
   }) async {
-    // print('Stashing changes with message: $message');
-    // await Future.delayed(const Duration(seconds: 1));
+    print('Stashing changes with message: $message');
+    await Future.delayed(const Duration(seconds: 1));
   }
 
   /// Apply the stash at the given [stashRef] to the working directory.

--- a/example/lib/stash.g.dart
+++ b/example/lib/stash.g.dart
@@ -9,7 +9,7 @@ part of 'stash.dart';
 class _$StashSubcommand extends Command {
   _$StashSubcommand() {
     final upcastedType = (this as StashSubcommand);
-    addSubcommand(MyCustomCommand(upcastedType.myCustomCommand));
+    addSubcommand(PushCommand(upcastedType.push));
     addSubcommand(ApplyCommand(upcastedType.apply));
   }
 
@@ -20,89 +20,30 @@ class _$StashSubcommand extends Command {
   String get description => 'Commands for managing a stack of stashed changes.';
 }
 
-class MyCustomCommand extends Command {
-  MyCustomCommand(this.userMethod) {
-    argParser
-      ..addOption(
-        'name',
-        mandatory: true,
-      )
-      ..addOption(
-        'age',
-        mandatory: false,
-      )
-      ..addOption(
-        'default-path',
-        defaultsTo: '~/',
-        mandatory: false,
-      )
-      ..addOption(
-        'some-documented-parameter',
-        mandatory: false,
-      )
-      ..addOption(
-        'custom-parameter',
-        help: 'A custom help message for the parameter',
-        defaultsTo: '42',
-        mandatory: false,
-      );
-  }
+class PushCommand extends Command {
+  PushCommand(this.userMethod);
 
-  final Function({
-    required String name,
-    int? age,
-    String defaultPath,
-    String? someDocumentedParameter,
-    int? customParameter,
-  }) userMethod;
+  final Function({String message}) userMethod;
 
   @override
-  String get name => 'my-custom-command';
+  String get name => 'push';
 
   @override
   String get description => 'Save your local modifications to a new stash.';
 
-  // @override
-  // ArgParser get argParser => ArgParser()
-  //   ..addOption(
-  //     'name',
-  //     mandatory: true,
-  //   )
-  //   ..addOption(
-  //     'age',
-  //     mandatory: false,
-  //   )
-  //   ..addOption(
-  //     'default-path',
-  //     defaultsTo: '~/',
-  //     mandatory: false,
-  //   )
-  //   ..addOption(
-  //     'some-documented-parameter',
-  //     mandatory: false,
-  //   )
-  //   ..addOption(
-  //     'custom-parameter',
-  //     help: 'A custom help message for the parameter',
-  //     defaultsTo: '42',
-  //     mandatory: false,
-  //   );
+  @override
+  ArgParser get argParser => ArgParser()
+    ..addOption(
+      'message',
+      defaultsTo: 'WIP',
+      mandatory: false,
+    );
 
   @override
   Future<void> run() {
     final results = argResults!;
     return userMethod(
-      name: results['name'],
-      age: results['age'] != null ? int.parse(results['age']) : null,
-      defaultPath:
-          results['default-path'] != null ? results['default-path'] : '~/',
-      someDocumentedParameter: results['some-documented-parameter'] != null
-          ? results['some-documented-parameter']
-          : null,
-      customParameter: results['custom-parameter'] != null
-          ? int.parse(results['custom-parameter'])
-          : null,
-    );
+        message: results['message'] != null ? results['message'] : 'WIP');
   }
 }
 

--- a/src/cli_gen/lib/src/analysis/commands/cli_runner_analyzer.dart
+++ b/src/cli_gen/lib/src/analysis/commands/cli_runner_analyzer.dart
@@ -1,7 +1,10 @@
-import 'package:analyzer/dart/element/element.dart';
-import 'package:code_builder/code_builder.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/ast/utilities.dart';
 
+import '../../code/models/command_method_model.dart';
 import '../../code/models/runner_model.dart';
+import '../utils/reference_ext.dart';
 import '../utils/remove_doc_slashes.dart';
 import 'cli_command_analyzer.dart';
 
@@ -10,19 +13,31 @@ class CliRunnerAnalyzer {
 
   /// Extracts ClassElement info required to build the CommandRunner into a [RunnerModel].
   RunnerModel fromClassElement(
-    ClassElement element,
+    ClassDeclaration node,
   ) {
+    final element = node.declaredElement!;
     const commandMethodAnalyzer = CliCommandAnalyzer();
+
+    List<CommandMethodModel> commandMethods = [];
+
+    for (final method in element.methods) {
+      if (commandMethodAnalyzer.isAnnotatedWithCliCommand(method)) {
+        final methodNode = NodeLocator(
+          method.nameOffset,
+          method.nameOffset + method.nameLength,
+        ).searchWithin(node) as MethodDeclaration;
+        commandMethods.add(
+          commandMethodAnalyzer.fromMethodDeclaration(methodNode),
+        );
+      }
+    }
 
     return RunnerModel(
       mountedSubcommands: [...element.accessors, ...element.methods]
           .where(commandMethodAnalyzer.isAnnotatedWithSubcommandMount)
-          .map((e) => refer(e.name, e.librarySource.uri.toString()))
+          .map((e) => e.toRef())
           .toList(),
-      commandMethods: element.methods
-          .where(commandMethodAnalyzer.isAnnotatedWithCliCommand)
-          .map(commandMethodAnalyzer.fromExecutableElement)
-          .toList(),
+      commandMethods: commandMethods,
       docComments: removeDocSlashes(element.documentationComment),
       userClassName: element.name,
     );

--- a/src/cli_gen/lib/src/analysis/commands/cli_subcommand_analyzer.dart
+++ b/src/cli_gen/lib/src/analysis/commands/cli_subcommand_analyzer.dart
@@ -1,27 +1,41 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/ast/utilities.dart';
 import 'package:code_builder/code_builder.dart';
 
+import '../../code/models/command_method_model.dart';
 import '../../code/models/subcommand_model.dart';
-import 'cli_command_analyzer.dart';
 import '../utils/remove_doc_slashes.dart';
+import 'cli_command_analyzer.dart';
 
 class CliSubcommandAnalyzer {
   const CliSubcommandAnalyzer();
 
   SubcommandModel fromClassElement(
-    ClassElement element,
+    ClassDeclaration node,
   ) {
+    final element = node.declaredElement!;
     const commandMethodAnalyzer = CliCommandAnalyzer();
 
+    List<CommandMethodModel> commandMethods = [];
+
+    for (final method in element.methods) {
+      if (commandMethodAnalyzer.isAnnotatedWithCliCommand(method)) {
+        final methodNode = NodeLocator(
+          method.nameOffset,
+          method.nameOffset + method.nameLength,
+        ).searchWithin(node) as MethodDeclaration;
+        commandMethods.add(
+          commandMethodAnalyzer.fromMethodDeclaration(methodNode),
+        );
+      }
+    }
     return SubcommandModel(
       mountedSubcommands: [...element.accessors, ...element.methods]
           .where(commandMethodAnalyzer.isAnnotatedWithSubcommandMount)
           .map((e) => refer(e.name, e.librarySource.uri.toString()))
           .toList(),
-      commandMethods: element.methods
-          .where(commandMethodAnalyzer.isAnnotatedWithCliCommand)
-          .map(commandMethodAnalyzer.fromExecutableElement)
-          .toList(),
+      commandMethods: commandMethods,
       docComments: removeDocSlashes(element.documentationComment),
       userClassName: element.name,
     );

--- a/src/cli_gen/lib/src/builders/subcommand_generator.dart
+++ b/src/cli_gen/lib/src/builders/subcommand_generator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:cli_annotations/cli_annotations.dart';
@@ -12,11 +13,11 @@ import '../code/command/subcommand_builder.dart';
 
 class SubcommandGenerator extends GeneratorForAnnotation<CliSubcommand> {
   @override
-  FutureOr<String> generateForAnnotatedElement(
+  Future<String> generateForAnnotatedElement(
     Element element,
     ConstantReader annotation,
     BuildStep buildStep,
-  ) {
+  ) async {
     if (element is! ClassElement) {
       throw InvalidGenerationSourceError(
         'The `@CliSubcommand` annotation can only be used on classes.',
@@ -25,7 +26,15 @@ class SubcommandGenerator extends GeneratorForAnnotation<CliSubcommand> {
     }
 
     const subcommandAnalyzer = CliSubcommandAnalyzer();
-    final model = subcommandAnalyzer.fromClassElement(element);
+    final resolver = buildStep.resolver;
+    final classNode = await resolver.astNodeFor(element, resolve: true);
+    if (classNode is! ClassDeclaration) {
+      throw InvalidGenerationSourceError(
+        'The `@CliRunner` annotation can only be used on classes.',
+        element: element,
+      );
+    }
+    final model = subcommandAnalyzer.fromClassElement(classNode);
 
     final library = Library((builder) {
       const subcommandBuilder = SubcommandBuilder();


### PR DESCRIPTION
This PR is tracking a refactor to allow doc comments to be inferred from the `ASTNode` tree. 

## Problem

The Dart analyzer's Element model allows for accessing doc comments on an Element, but ParameterElements only ever contain doc comments if they are a Formal Parameter that relates to a field.

```dart
/// Command-level doc comment
@cliCommand
Future<void> myCustomCommand({
  // Parameter doc comment (not available in ParameterElement.docComments)
  required String requiredParam,
)} { /* ... */ }


class Foo {
  /// Field-level doc comment
  final String myField;

  const Foo({
    required this.myField, // parameter `this.myField` inherits doc comments from `myField`
  )};
```

Only in the second case are we able to get doc comments from the Parameter element. What this means is that there is no idiomatic Dart way of inferring `--help` comments from a Parameter, at least from the element model.

## Potential Solutions

### Access doc comments via ASTNode

We're easily able to get the doc comment via the ASTNode of the parameter. Users would simply document the parameter of a method/function (as shown above) which would generate the help text.

However, for the upcoming macros feature, it's unclear whether or not the API will allow access to the ASTs. If it is an option (or if we can e.g. read the raw source code and parse it ourselves), then this would likely be the go-to solution. If the AST tree is not available to macros, though, then this would be a case where the user experience is different between `build_runner` and `macros`.

[relevant issue](https://github.com/dart-lang/language/issues/3611)

### Doc Comments via Annotations

We already ship an `@Option` annotation, which allows doc comments and other explicit values to reach the element model via constant evaluation (i.e. the `DartObject` interface). 

```dart
@cliCommand
Future<void> myCustomCommand({
  @Option(help: 'My parameter doc comment')
  required String requiredParam,
)} { /* ... */ }
```

This isn't the most elegant solution, but it gets the job done. In the case of documenting every single parameter of a method, if users create complex methods with many args, the amount of annotation use will surely be a negative experience.

### `Arg` classes

Another solution is to recommend that users create separate Arg classes for each function, which would allow users to generate help text from doc comments on the `Field`s of the Arg class.

```dart
@cliArgs
class MyCustomCommandArgs {
  const MyCustomCommandArgs({
    required this.requiredParam,
  )};

  /// Some doc comment
  final String requiredParam;
}

// usage below

@cliCommand
Future<void> myCustomCommand(
  MyCustomCommandArgs args,
} { /* ... */ }
```

This solution makes intuitive sense, and we could recommend this approach for all argument generation, so that it becomes the default way of doing things (rather than individual parameters on a method/function). We lose a little flexibility and gain some verbosity, but in return gain a good amount too. Its possible that `macros` would help trim the verbosity a good amount as well.

This solution needs a little more investigation to see how effective it is in practice.
